### PR TITLE
Fix: Correct YAML syntax in plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: GemsEconomyReloaded
 main: me.xanium.gemseconomy.GemsEconomy
 version: 4.9.3
 author: Minekarta Studio
-description: GemsEconomy Reloaded plugin is a maintained version of the original plugin name GemsEconomy: https://github.com/Xanium1/GemsEconomy
+description: 'GemsEconomy Reloaded plugin is a maintained version of the original plugin name GemsEconomy: https://github.com/Xanium1/GemsEconomy'
 website: https://www.spigotmc.org/resources/gemseconomy.19655/
 load: STARTUP
 api-version: 1.21


### PR DESCRIPTION
The 'description' field in plugin.yml contained a colon, which caused a YAML parsing error and prevented the plugin from loading.

This change wraps the description string in single quotes to ensure it is parsed correctly as a single literal value.